### PR TITLE
Added --offset and --duration options

### DIFF
--- a/mlbam/nhlv.py
+++ b/mlbam/nhlv.py
@@ -83,6 +83,7 @@ def main(argv=None):
     parser.add_argument("-r", "--resolution", choices=config.BANDWIDTH_CHOICES,
                         help="Stream resolution for streamlink (overrides settting in config file)")
     parser.add_argument("--from-start", action="store_true", help="Start live/archive stream from beginning")
+    parser.add_argument("--offset", help="Amount of time (HH:MM:SS) to skip from the beginning of the stream. For live streams, this is a negative offset from the end of the stream (rewind).")
     parser.add_argument("--favs", help=argparse.SUPPRESS)
                         # help=("Favourite teams, a comma-separated list of favourite teams " "(normally specified in config file)"))
     parser.add_argument("--filter", nargs='?', const='favs', metavar='filtername|teams',
@@ -212,7 +213,7 @@ def main(argv=None):
                     LOG.info("Playing recap for %s at %s", game_rec['away_abbrev'].upper(), game_rec['home_abbrev'].upper())
                     stream_game_rec = stream.get_game_rec(game_data, game_rec['home_abbrev'])
                     stream.play_stream(stream_game_rec, game_rec['home_abbrev'], 'recap', game_date,
-                                       args.fetch, None, None, is_multi_highlight=True)
+                                       args.fetch, None, None, offset=args.offset, is_multi_highlight=True)
                 else:
                     LOG.info("No recap available for %s at %s", game_rec['away_abbrev'].upper(), game_rec['home_abbrev'].upper())
         return 0
@@ -240,7 +241,7 @@ def main(argv=None):
 
         game_rec = stream.get_game_rec(game_data, team_to_play)
 
-    return stream.play_stream(game_rec, team_to_play, feedtype, args.date, args.fetch, auth.nhl_login, args.from_start)
+    return stream.play_stream(game_rec, team_to_play, feedtype, args.date, args.fetch, auth.nhl_login, args.from_start, offset=args.offset)
 
 
 if __name__ == "__main__" or __name__ == "main":

--- a/mlbam/nhlv.py
+++ b/mlbam/nhlv.py
@@ -83,7 +83,8 @@ def main(argv=None):
     parser.add_argument("-r", "--resolution", choices=config.BANDWIDTH_CHOICES,
                         help="Stream resolution for streamlink (overrides settting in config file)")
     parser.add_argument("--from-start", action="store_true", help="Start live/archive stream from beginning")
-    parser.add_argument("--offset", help="Amount of time (HH:MM:SS) to skip from the beginning of the stream. For live streams, this is a negative offset from the end of the stream (rewind).")
+    parser.add_argument("--offset", help="Amount of time (HH:MM:SS) to skip from the beginning of the stream. For live streams, this is a negative offset from the end of the stream (rewind)")
+    parser.add_argument("--duration", help="Limit the playback duration, useful for watching segments of a stream")
     parser.add_argument("--favs", help=argparse.SUPPRESS)
                         # help=("Favourite teams, a comma-separated list of favourite teams " "(normally specified in config file)"))
     parser.add_argument("--filter", nargs='?', const='favs', metavar='filtername|teams',
@@ -213,7 +214,7 @@ def main(argv=None):
                     LOG.info("Playing recap for %s at %s", game_rec['away_abbrev'].upper(), game_rec['home_abbrev'].upper())
                     stream_game_rec = stream.get_game_rec(game_data, game_rec['home_abbrev'])
                     stream.play_stream(stream_game_rec, game_rec['home_abbrev'], 'recap', game_date,
-                                       args.fetch, None, None, offset=args.offset, is_multi_highlight=True)
+                                       args.fetch, None, None, offset=args.offset, duration=args.duration, is_multi_highlight=True)
                 else:
                     LOG.info("No recap available for %s at %s", game_rec['away_abbrev'].upper(), game_rec['home_abbrev'].upper())
         return 0
@@ -241,7 +242,7 @@ def main(argv=None):
 
         game_rec = stream.get_game_rec(game_data, team_to_play)
 
-    return stream.play_stream(game_rec, team_to_play, feedtype, args.date, args.fetch, auth.nhl_login, args.from_start, offset=args.offset)
+    return stream.play_stream(game_rec, team_to_play, feedtype, args.date, args.fetch, auth.nhl_login, args.from_start, offset=args.offset, duration=args.duration)
 
 
 if __name__ == "__main__" or __name__ == "main":

--- a/mlbam/stream.py
+++ b/mlbam/stream.py
@@ -167,7 +167,7 @@ def get_game_rec(game_data, team_to_play):
     return game_rec
 
 
-def play_stream(game_rec, team_to_play, feedtype, date_str, fetch, login_func, from_start, is_multi_highlight=False):
+def play_stream(game_rec, team_to_play, feedtype, date_str, fetch, login_func, from_start, offset=None, is_multi_highlight=False):
     if feedtype is not None and feedtype in config.HIGHLIGHT_FEEDTYPES:
         # handle condensed/recap
         playback_url = find_highlight_url_for_team(game_rec, feedtype)
@@ -189,7 +189,6 @@ def play_stream(game_rec, team_to_play, feedtype, date_str, fetch, login_func, f
         if media_playback_id is not None:
             stream_url, media_auth = fetch_stream(game_rec['game_pk'], media_playback_id, event_id)
             if stream_url is not None:
-                offset = None
                 if config.SAVE_PLAYLIST_FILE:
                     save_playlist_to_file(stream_url, media_auth)
                 streamlink(stream_url, media_auth, get_fetch_filename(date_str, game_rec, feedtype, fetch), from_start, offset)

--- a/mlbam/stream.py
+++ b/mlbam/stream.py
@@ -261,7 +261,9 @@ def streamlink(stream_url, media_auth, fetch_filename=None, from_start=False, of
                       "--player-no-close",
                       "--http-cookie", auth_cookie_str,
                       "--http-cookie", media_auth_cookie_str,
-                      "--http-header", user_agent_hdr]
+                      "--http-header", user_agent_hdr,
+                      "--hls-timeout", "600.0",
+                      "--hls-segment-timeout", "60.0"]
     if from_start:
         streamlink_cmd.append("--hls-live-restart")
         LOG.info("Starting from beginning [--hls-live-restart]")
@@ -280,7 +282,7 @@ def streamlink(stream_url, media_auth, fetch_filename=None, from_start=False, of
             # don't overwrite existing file - use a new name based on hour,minute
             fetch_filename_orig = fetch_filename
             fsplit = os.path.splitext(fetch_filename)
-            fetch_filename = '{}-{}{}'.format(fsplit[0], datetime.strftime(datetime.today(), "%H%m"), fsplit[1])
+            fetch_filename = '{}-{}{}'.format(fsplit[0], datetime.strftime(datetime.today(), "%H%M"), fsplit[1])
             LOG.info('File %s exists, using %s instead', fetch_filename_orig, fetch_filename)
         streamlink_cmd.append("--output")
         streamlink_cmd.append(fetch_filename)

--- a/mlbam/stream.py
+++ b/mlbam/stream.py
@@ -167,7 +167,7 @@ def get_game_rec(game_data, team_to_play):
     return game_rec
 
 
-def play_stream(game_rec, team_to_play, feedtype, date_str, fetch, login_func, from_start, offset=None, is_multi_highlight=False):
+def play_stream(game_rec, team_to_play, feedtype, date_str, fetch, login_func, from_start, offset=None, duration=None, is_multi_highlight=False):
     if feedtype is not None and feedtype in config.HIGHLIGHT_FEEDTYPES:
         # handle condensed/recap
         playback_url = find_highlight_url_for_team(game_rec, feedtype)
@@ -191,7 +191,7 @@ def play_stream(game_rec, team_to_play, feedtype, date_str, fetch, login_func, f
             if stream_url is not None:
                 if config.SAVE_PLAYLIST_FILE:
                     save_playlist_to_file(stream_url, media_auth)
-                streamlink(stream_url, media_auth, get_fetch_filename(date_str, game_rec, feedtype, fetch), from_start, offset)
+                streamlink(stream_url, media_auth, get_fetch_filename(date_str, game_rec, feedtype, fetch), from_start, offset, duration)
             else:
                 LOG.error("No stream URL found")
         else:
@@ -249,7 +249,7 @@ def streamlink_highlight(playback_url, fetch_filename, is_multi_highlight=False)
     subprocess.run(streamlink_cmd)
 
 
-def streamlink(stream_url, media_auth, fetch_filename=None, from_start=False, offset=None):
+def streamlink(stream_url, media_auth, fetch_filename=None, from_start=False, offset=None, duration=None):
     LOG.debug("Stream url: " + stream_url)
     auth_cookie_str = "Authorization=" + auth.get_auth_cookie()
     media_auth_cookie_str = media_auth
@@ -269,6 +269,11 @@ def streamlink(stream_url, media_auth, fetch_filename=None, from_start=False, of
         streamlink_cmd.append("--hls-start-offset")
         streamlink_cmd.append(offset)
         LOG.debug("Using --hls-start-offset %s", offset)
+
+    if duration:
+        streamlink_cmd.append("--hls-duration")
+        streamlink_cmd.append(duration)
+        LOG.debug("Using --hls-duration %s", duration)
 
     if fetch_filename is not None:
         if os.path.exists(fetch_filename):

--- a/nhlv
+++ b/nhlv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Wrapper to call in to nhlv.py if not installed via pip
 """


### PR DESCRIPTION
This adds the ability to start fetching the stream at arbitrary point of broadcast with --offset option.  This could be useful if one wants to restart download that crashed (e.g. streamlink exits with read timeout) or trim the resulting video without first downloading it.

Also added is --duration option, which limits the duration of the fetched stream.  Combined with offset, this should allow to get any combination of segments of the broadcast - for example, if one is looking to just download intermission videos.

By the way, some elements were already in the code for offset option, I really just added argument to argparse and made sure it's passed to play_stream and streamlink methods.